### PR TITLE
Update wp-rocket-cli on Packagist to v1.1.2 from GeekPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 ## CLI interface for the WP Rocket
 
 This repository contains a [WP-CLI command](https://github.com/wp-cli/wp-cli)  for the [WP Rocket](http://wp-rocket.me) plugin. After installing this plugin, you will have access to a `wp rocket` command.
@@ -16,7 +17,7 @@ Currently supported commands:
 If you're using WP-CLI v0.23.0 or later, you can install this package with:
 
 ```
-wp package install geekpress/wp-rocket-cli
+wp package install wp-media/wp-rocket-cli
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently supported commands:
 * `wp rocket activate` -- Set WP_CACHE to true.
 * `wp rocket deactivate` -- Set WP_CACHE to false.
 * `wp rocket clean --post_id=<post_id> --permalink=<permalink> --lang=<lang> --blog_id=<blog_id>` -- Purge cache files.
+* `wp rocket clean --confirm` -- Purge cache files without prompting for confirmation (usefull for automation tools/scripts)
 * `wp rocket preload` -- Preload cache files.
 * `wp rocket regenerate --file=<file>` -- Regenerate .htaccess, advanced-cache.php or the WP Rocket config file.
     

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Currently supported commands:
     
 ## Installing
 
-For instructions on installing this, and other, WP-CLI community packages, read the [Community Packages](https://github.com/wp-cli/wp-cli/wiki/Community-Packages) section of the WP-CLI Wiki. 
+If you're using WP-CLI v0.23.0 or later, you can install this package with:
+
+```
+wp package install GeekPress/wp-rocket-cli
+```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## CLI interface for the WP Rocket
 
-This repository contains a [WP-CLI plugin](https://github.com/wp-cli/wp-cli)  for the [WP Rocket](http://wp-rocket.me) plugin. After installing this plugin, you will have access to a `wp rocket` command.
+This repository contains a [WP-CLI command](https://github.com/wp-cli/wp-cli)  for the [WP Rocket](http://wp-rocket.me) plugin. After installing this plugin, you will have access to a `wp rocket` command.
 
 Currently supported commands:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supported commands:
 If you're using WP-CLI v0.23.0 or later, you can install this package with:
 
 ```
-wp package install GeekPress/wp-rocket-cli
+wp package install geekpress/wp-rocket-cli
 ```
 
 ## Changelog

--- a/command.php
+++ b/command.php
@@ -224,11 +224,11 @@ class WPRocket_CLI extends WP_CLI_Command {
 		} else {
 
 			if ( ! empty( $assoc_args['confirm'] ) && $assoc_args['confirm'] ) {
-				WP_CLI::line('Deleting all cache files.');
+				WP_CLI::line( 'Deleting all cache files.' );
 			} else {
-				WP_CLI::confirm('Delete all cache files ?');
+				WP_CLI::confirm( 'Delete all cache files ?' );
 			}
-			
+
 			rocket_clean_domain();
 			WP_CLI::success( 'All cache files cleared.' );
 
@@ -246,25 +246,19 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 * @subcommand preload
 	 */
 	public function preload( $args = array(), $assoc_args = array() ) {
-
-		if ( rocket_has_i18n() ) {
-			run_rocket_bot_for_all_langs();
-		} else {
-		    run_rocket_bot( 'cache-preload' );
-		}
+		run_rocket_bot( 'cache-preload' );
 
 		WP_CLI::success( 'Finished WP Rocket preload cache files.' );
-
 	}
-	
+
 	/**
-	 * Regenerate file 
+	 * Regenerate file
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--file=<file>]
-	 * : The file to regenerate. It could be: 
-	 *	- htaccess 
+	 * : The file to regenerate. It could be:
+	 *	- htaccess
 	 *	- advanced-cache
 	 *	- config (It's the config file stored in the wp-rocket-config folder)
 	 *
@@ -279,22 +273,22 @@ class WPRocket_CLI extends WP_CLI_Command {
 			switch( $assoc_args['file'] ) {
 				case 'advanced-cache':
 					rocket_generate_advanced_cache_file();
-					WP_CLI::success( 'The advanced-cache.php file has just been regenerated.' );	
+					WP_CLI::success( 'The advanced-cache.php file has just been regenerated.' );
 					break;
 				case 'config':
 					rocket_generate_config_file();
-					WP_CLI::success( 'The config file has just been regenerated.' );	
+					WP_CLI::success( 'The config file has just been regenerated.' );
 					break;
 				case 'htaccess':
 					$GLOBALS['is_apache'] = true;
 					flush_rocket_htaccess();
-					WP_CLI::success( 'The .htaccess file has just been regenerated.' );	
+					WP_CLI::success( 'The .htaccess file has just been regenerated.' );
 					break;
 				default:
 					WP_CLI::error( 'You don\'t specify a good value for the "file" argument. It should be: advanced-cache, config or htaccess.' );
 					break;
 			}
-			
+
 		} else {
 			WP_CLI::error( 'You don\'t specify the "file" argument.' );
 		}

--- a/command.php
+++ b/command.php
@@ -73,6 +73,9 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 * [--blog_id=<blog_id>]
 	 * : List blogs to purge cache files. Trumps --post_id & --permalink & lang.
 	 *
+	 * [--confirm]
+	 * : Automatic 'yes' to any confirmation
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp rocket clean
@@ -220,7 +223,12 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 		} else {
 
-			WP_CLI::confirm( 'Delete all cache files ?' );
+			if ( ! empty( $assoc_args['confirm'] ) && $assoc_args['confirm'] ) {
+				WP_CLI::line('Deleting all cache files.');
+			} else {
+				WP_CLI::confirm('Delete all cache files ?');
+			}
+			
 			rocket_clean_domain();
 			WP_CLI::success( 'All cache files cleared.' );
 

--- a/command.php
+++ b/command.php
@@ -127,7 +127,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 		} else if( ! empty( $assoc_args['lang'] ) ) {
 
-			if( ! rocket_has_translation_plugin_active() ) {
+			if( ! rocket_has_i18n() ) {
 				WP_CLI::error( 'No WPML or qTranslate in this website.' );
 			}
 
@@ -222,7 +222,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 			WP_CLI::confirm( 'Delete all cache files ?' );
 
-			if( rocket_has_translation_plugin_active() ) {
+			if( rocket_has_i18n() ) {
 				rocket_clean_domain_for_all_langs();
 			} else {
 				rocket_clean_domain();
@@ -245,7 +245,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 */
 	public function preload( $args = array(), $assoc_args = array() ) {
 
-		if ( rocket_has_translation_plugin_active() ) {
+		if ( rocket_has_i18n() ) {
 			run_rocket_bot_for_all_langs();
 		} else {
 		    run_rocket_bot( 'cache-preload' );

--- a/command.php
+++ b/command.php
@@ -221,13 +221,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 		} else {
 
 			WP_CLI::confirm( 'Delete all cache files ?' );
-
-			if( rocket_has_i18n() ) {
-				rocket_clean_domain_for_all_langs();
-			} else {
-				rocket_clean_domain();
-			}
-
+			rocket_clean_domain();
 			WP_CLI::success( 'All cache files cleared.' );
 
 		}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "GeekPress/wp-rocket-cli",
+    "name": "wp-media/wp-rocket-cli",
     "type": "wp-cli-package",
     "description": "Add a `wp rocket` command to support the WP Rocket plugin",
     "keywords": ["wp-cli", "rocket", "cache"],
-    "homepage": "https://github.com/GeekPress/wp-rocket-cli",
+    "homepage": "https://github.com/wp-media/wp-rocket-cli",
     "license": "MIT",
     "require": {
         "php": ">=5.3.0"
@@ -15,8 +15,8 @@
         "role": "Developer"
     }],
     "support": {
-		"issues": "https://github.com/GeekPress/wp-rocket-cli/issues",
-		"source": "https://github.com/GeekPress/wp-rocket-cli"
+		"issues": "https://github.com/wp-media/wp-rocket-cli/issues",
+		"source": "https://github.com/wp-media/wp-rocket-cli"
 	},
     "autoload": {
         "files": [ "wp-rocket-cli.php" ]

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "GeekPress/wp-rocket-cli",
-    "type": "command",
+    "type": "wp-cli-package",
     "description": "Add a `wp rocket` command to support the WP Rocket plugin",
     "keywords": ["wp-cli", "rocket", "cache"],
     "homepage": "https://github.com/GeekPress/wp-rocket-cli",

--- a/wp-rocket-cli.php
+++ b/wp-rocket-cli.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Plugin Name: WR Rocket CLI
+ * Plugin Name: WP Rocket CLI
  * Plugin URI:
  * Description:
  * Version: 1.0


### PR DESCRIPTION
Update wp-rocket-cli with new feature and type for those using Composer as this repo is the one used on Packagist: [https://packagist.org/packages/geekpress/wp-rocket-cli](https://packagist.org/packages/geekpress/wp-rocket-cli)